### PR TITLE
Fix bugs and write tests

### DIFF
--- a/contracts/interfaces/IGitConsensus.sol
+++ b/contracts/interfaces/IGitConsensus.sol
@@ -21,10 +21,17 @@ interface IGitConsensusErrors {
     /// @dev Can occur with `addRelease()`.
     error DistributionLengthMismatch(uint256 hashesLen, uint256 valuesLen);
     /// @notice When a release attempt occurs from a sender other than the project's governor.
-    /// @param senderAddr The address of the unathorized sender.
+    /// @param senderAddr The address of the unauthorized sender.
     /// @param expectedAddr The expected address, which should be the governor.
     /// @dev Can occur with `addRelease()`.
     error UnauthorizedRelease(address senderAddr, address expectedAddr);
+    /// @notice When the sender attempts to extract a substring that is out of bounds in a
+    /// string.
+    /// @param offset The index of the substring to extract.
+    /// @param substringLen The length of the substring to extract.
+    /// @param stringLen The length of the string from which to extract the substring.
+    /// @dev Can occur with `addCommit()` or `addRelease()`.
+    error SubstringOutOfBounds(uint256 offset, uint256 substringLen, uint256 stringLen);
 }
 
 /// @title  IGitConsensusEvents

--- a/contracts/lib/Utils.sol
+++ b/contracts/lib/Utils.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity >=0.8.17;
 import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import {IGitConsensusErrors} from "../interfaces/IGitConsensus.sol";
 
 /// @title  Utils
 /// @notice A collection of utility functions for Git Consensus.
@@ -23,7 +24,7 @@ library Utils {
     function indexOfAddr(string memory _base) internal pure returns (uint256 pos_) {
         bytes memory _baseBytes = bytes(_base);
 
-        for (uint256 i = _baseBytes.length - 1; i > 0; i--) {
+        for (uint256 i = _baseBytes.length - 1; i > 0; --i) {
             if (_baseBytes[i - 1] == "0" && _baseBytes[i] == "x") {
                 return i - 1;
             }
@@ -46,12 +47,14 @@ library Utils {
         bytes memory _baseBytes = bytes(_base);
 
         (bool success, uint256 endIdx) = SafeMath.tryAdd(_offset, _length);
-        require(success && endIdx <= _baseBytes.length, "Utils: substring out of bounds");
+        if (!success || endIdx > _baseBytes.length) {
+            revert IGitConsensusErrors.SubstringOutOfBounds(_offset, _length, _baseBytes.length);
+        }
 
         string memory _tmp = new string(_length);
         bytes memory _tmpBytes = bytes(_tmp);
 
-        for (uint256 i = _offset; i < endIdx; i++) {
+        for (uint256 i = _offset; i < endIdx; ++i) {
             _tmpBytes[i - _offset] = _baseBytes[i];
         }
 

--- a/contracts/test/Utils.t.sol
+++ b/contracts/test/Utils.t.sol
@@ -2,8 +2,9 @@
 pragma solidity >=0.8.17;
 import {Test} from "./utils/Test.sol";
 import {Utils as LibUtils} from "../lib/Utils.sol";
+import {IGitConsensusErrors} from "../interfaces/IGitConsensus.sol";
 
-contract UtilsTest is Test {
+contract UtilsTest is Test, IGitConsensusErrors {
     string private constant ADDR_STR = "0xC257274276a4E539741Ca11b590B9447B26A8051";
     address private constant ADDR = 0xC257274276a4E539741Ca11b590B9447B26A8051;
     string private constant COMMIT_MSG_BASE = "Lorem ipsum dolor sit amet.";
@@ -40,13 +41,18 @@ contract UtilsTest is Test {
     }
 
     function testOk_substringOutOfBoundsNoOverflow() public {
-        vm.expectRevert(bytes("Utils: substring out of bounds"));
+        vm.expectRevert(
+            abi.encodeWithSelector(SubstringOutOfBounds.selector, bytes(COMMIT_MSG).length,
+            bytes(COMMIT_MSG).length, bytes(COMMIT_MSG).length)
+        );
         LibUtils.substring(COMMIT_MSG, bytes(COMMIT_MSG).length, bytes(COMMIT_MSG).length);
     }
 
     function testOk_substringOutOfBoundsOverflow() public {
-        vm.expectRevert(bytes("Utils: substring out of bounds"));
-
+          vm.expectRevert(
+            abi.encodeWithSelector(SubstringOutOfBounds.selector, 1,
+            MAX_UINT256, bytes(COMMIT_MSG).length)
+        );
         LibUtils.substring(COMMIT_MSG, 1, MAX_UINT256);
     }
 
@@ -54,4 +60,3 @@ contract UtilsTest is Test {
         assertEq(LibUtils.parseAddr(ADDR_STR), ADDR);
     }
 }
-


### PR DESCRIPTION
# Description
* Fix unsigned underflow bug when iterating to `0`-th index in `Utils.sol::indexOfAddr`
* Improve error-handling for unsigned overflow in `Utils.sol::substring`
* Write tests for `lib/Utils.sol`

# Test Coverage
```
 forge test
[⠒] Compiling...
[⠊] Compiling 1 files with 0.8.17
[⠒] Solc 0.8.17 finished in 778.44ms
Compiler run successful

Running 2 tests for contracts/test/GitConsensus.t.sol:GasBenchmark
[PASS] testGas_commit() (gas: 433200)
[PASS] testGas_release() (gas: 432232)
Test result: ok. 2 passed; 0 failed; finished in 852.57ms

Running 10 tests for contracts/test/Utils.t.sol:UtilsTest
[PASS] testOK_parseAddrGeneralCase() (gas: 23336)
[PASS] testOk_indexOfAddrNonexistentADDR_STRNonemptyMsg() (gas: 6515)
[PASS] testOk_indexOfAddressGeneralCase() (gas: 10596)
[PASS] testOk_indexOfAddressNonexistentADDR_STREmptyMsg() (gas: 257)
[PASS] testOk_indexOfAddressTrivialCase() (gas: 10303)
[PASS] testOk_substringEmptyString() (gas: 1168)
[PASS] testOk_substringEntireString() (gas: 11962)
[PASS] testOk_substringGeneralCase() (gas: 25086)
[PASS] testOk_substringOutOfBoundsNoOverflow() (gas: 7320)
[PASS] testOk_substringOutOfBoundsOverflow() (gas: 6263)
Test result: ok. 10 passed; 0 failed; finished in 2.07s

Running 17 tests for contracts/test/GitConsensus.t.sol:WhenCallingGitConsensus
[PASS] testOk_commitEmptyFailed(address) (runs: 256, μ: 61493, ~: 61493)
[PASS] testOk_commitEmptyMsgAddr(address) (runs: 256, μ: 348823, ~: 345190)
[PASS] testOk_commitEmptyMsgAddrMalformed(address) (runs: 256, μ: 93757, ~: 93757)
[PASS] testOk_commitFilledFailed(address) (runs: 256, μ: 952474, ~: 952474)
[PASS] testOk_commitFilledMsgAddr(address) (runs: 256, μ: 2136596, ~: 2132959)
[PASS] testOk_commitPartialFailed(address) (runs: 256, μ: 51803, ~: 51803)
[PASS] testOk_commitPartialMsgAddr(address) (runs: 256, μ: 335397, ~: 332130)
[PASS] testOk_commitTwoHashDiffMsgAddrNotMatch(address,address) (runs: 256, μ: 652630, ~: 645494)
[PASS] testOk_commitTwoHashDiffMsgAddrNotMatchWSender(address,address) (runs: 256, μ: 653228, ~: 646320)
[PASS] testOk_commitTwoHashDiffMsgStrNotMatch(address) (runs: 256, μ: 650000, ~: 643825)
[PASS] testOk_releaseEmptyFailed(address) (runs: 256, μ: 62171, ~: 62171)
[PASS] testOk_releaseEmptyMsgAddr(address) (runs: 256, μ: 347215, ~: 344089)
[PASS] testOk_releaseFilledFailed(address) (runs: 256, μ: 888248, ~: 888248)
[PASS] testOk_releaseFilledMsgAddr(address) (runs: 256, μ: 1941778, ~: 1938526)
[PASS] testOk_releasePartialFailed(address) (runs: 256, μ: 51862, ~: 51862)
[PASS] testOk_releasePartialMsgAddr(address) (runs: 256, μ: 334357, ~: 330907)
[PASS] testOk_releaseTwoHashDiffMsgStrNotMatch(address) (runs: 256, μ: 650260, ~: 643483)
Test result: ok. 17 passed; 0 failed; finished in 2.19s
```