### PR TITLE
update integration test to check for addRelease() minting and UnauthorizedRelease error

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -194,7 +194,7 @@ const config: HardhatUserConfig = {
         keepFileStructure: true,
         freshOutput: true,
         include: [`contracts/`], // idk why this includes imports but it do
-        exclude: [`contracts/lib/`,`contracts/test/`],
+        exclude: [`contracts/lib/`, `contracts/test/`],
     },
     contractSizer: {
         alphaSort: true,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "lint": "npx prettier --config ./.prettierrc.json --check . && npx eslint --no-ignore --no-error-on-unmatched-pattern \"**/*.{ts,tsx}\"",
         "pretty": "npx prettier --config ./.prettierrc.json --write . && npx eslint --no-ignore --no-error-on-unmatched-pattern --fix \"**/*.{ts,tsx}\"",
         "size": "npx hardhat size-contracts",
-        "test": "npx hardhat test --network hardhat --parallel",
+        "test": "npx hardhat test --network hardhat",
         "typechain": "npx hardhat typechain",
         "update": "forge update && yarn upgrade",
         "ut": "forge test"

--- a/scripts/const.ts
+++ b/scripts/const.ts
@@ -46,6 +46,7 @@ export enum GitConsensusErrors {
     TAG_MSG_NEEDS_ADDR = `TagMsgNeedsAddr`,
     DISTRIBUTION_LENGTH_MISMATCH = `DistributionLengthMismatch`,
     UNAUTHORIZED_RELEASE = `UnauthorizedRelease`,
+    SUBSTRING_OUT_OF_BOUNDS = `SubstringOutOfBounds`,
 }
 
 /// --- GOVERNOR TYPES ---


### PR DESCRIPTION
## **Description**

This tests for the functionality included in https://github.com/git-consensus/contracts/pull/6, which checks for the Governor address being the caller, and actually mints the tokens. 

This is accomplished by checking the change in the tokens `totalSupply()` and `balanceOf()`.

## **Test Coverage**

```
$ npx hardhat test --network hardhat

  Git Consensus integration tests
    commits
      ✓ should succeed single commit that have address
      ✓ should succeed single commit that have address no space
      - should fail all commit that have partial address
      ✓ [loop] should succeed all example commit that have address
      ✓ [loop] should fail all example commit that have no address
    releases
      ✓ should fail release with different size hash and value arrays
      ✓ [loop] should fail all example tag that have no address
      ✓ should fail invalid release from non-governor
      ✓ should succeed valid release, commits from last tag to current
      ✓ should succeed valid release, commits from any
    clones
      ✓ should create clones using arguments
```