### PR TITLE
update maxMintablePerHash to treat zero value as no max

### DIFF
--- a/contracts/clones/TokenImpl.sol
+++ b/contracts/clones/TokenImpl.sol
@@ -79,7 +79,7 @@ contract TokenImpl is
             revert UnauthorizedMinter(msg.sender, minterAddr);
         }
 
-        if (_amount > maxMintableTokensPerHash) {
+        if (maxMintableTokensPerHash != 0 && _amount > maxMintableTokensPerHash) {
             revert MaxMintablePerHashExceeded(_amount, maxMintableTokensPerHash);
         }
 

--- a/contracts/interfaces/IToken.sol
+++ b/contracts/interfaces/IToken.sol
@@ -74,7 +74,8 @@ interface IToken is ITokenErrors {
     /// @param name Name of the token (e.g. "MyToken").
     /// @param symbol Symbol of the token (e.g. "MTK").
     /// @param maxMintablePerHash The maximum value that can be minted for a single hash in
-    ///     the hashes array during `GitConsensus.addRelease(tagData, hashes, values)`.
+    ///     the hashes array during `GitConsensus.addRelease(tagData, hashes, values)`. If no
+    ///     maximum is desired, set to 0.
     /// @param owners Array of addresses to receive an initial distribution of tokens. MUST
     ///     equal length of `values`.
     /// @param values Array of amounts of tokens to be given to each owner. The initial
@@ -110,7 +111,7 @@ interface IToken is ITokenErrors {
 
     /// @notice Returns maximum value that a commit hash can recieve.
     /// @return max The maximum value a single commit hash can receive from the execution of
-    ///     `GitConsensus.addRelease()`.
+    ///     `GitConsensus.addRelease()`. A value of 0 means there is no maximum.
     /// @dev Aside from limiting the final distribution that is sent to `GitConsensus.addRelease()`,
     ///     this value also gives clients a reference for the maximum that a voter should be able
     ///     assign to a single commit during the pre-proposal stage. This pre-proposal stage allows

--- a/contracts/test/TokenFactory.t.sol
+++ b/contracts/test/TokenFactory.t.sol
@@ -3,11 +3,13 @@ pragma solidity >=0.8.17;
 
 import {IGitConsensusTypes} from "../interfaces/IGitConsensus.sol";
 import {ITokenFactoryEvents} from "../interfaces/ITokenFactory.sol";
+import {IToken} from "../interfaces/IToken.sol";
 import {IERC20Events} from "./utils/Events.sol";
 import {Test} from "./utils/Test.sol";
 import {Distibution} from "./utils/Distribution.sol";
 import {TokenFactory} from "../clones/TokenFactory.sol";
 import {TokenImpl} from "../clones/TokenImpl.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract BaseSetup is Test, IGitConsensusTypes, ITokenFactoryEvents, IERC20Events {
     TokenFactory internal factory;
@@ -268,6 +270,112 @@ contract WhenCreatingNewToken is BaseSetup {
 
     function testOk_predictTokenAddress(bytes32 _createSalt) public view {
         factory.predictAddress(_createSalt);
+    }
+}
+
+contract WhenAfterTokenCreated is BaseSetup {
+    function testOk_createdTokenZeroMaxMintablePerHash(
+        address _creatorAddr,
+        address _govAddr,
+        address _minterAddr,
+        string memory _name,
+        string memory _symbol,
+        bytes32 _createSalt
+    ) public {
+        vm.assume(_creatorAddr != address(0));
+        address[] memory owners = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        owners[0] = address(0);
+        values[0] = 0;
+
+        // zero values should be treated as no maximum
+        uint256 maxMintablePerHash = 0;
+
+        address expectedAddr = factory.predictAddress(_createSalt);
+        vm.expectEmit(true, false, false, true);
+        emit TokenCreated(
+            expectedAddr,
+            _creatorAddr,
+            _govAddr,
+            _minterAddr,
+            _name,
+            _symbol,
+            maxMintablePerHash
+        );
+
+        vm.prank(_creatorAddr);
+        address tokenAddr = factory.createToken(
+            _govAddr,
+            _minterAddr,
+            _name,
+            _symbol,
+            maxMintablePerHash,
+            owners,
+            values,
+            _createSalt
+        );
+
+        IToken token = IToken(tokenAddr);
+        assertEq(0, token.maxMintablePerHash());
+
+        vm.prank(_minterAddr);
+        token.mint(_creatorAddr, type(uint224).max); // maximum token supply for ERC20Votes
+        IERC20 tokenERC20 = IERC20(tokenAddr);
+        assertEq(type(uint224).max, tokenERC20.balanceOf(_creatorAddr));
+    }
+
+    function testOk_createdTokenAboveMaxMintablePerHashFailed(
+        address _creatorAddr,
+        address _govAddr,
+        address _minterAddr,
+        string memory _name,
+        string memory _symbol,
+        bytes32 _createSalt
+    ) public {
+        vm.assume(_creatorAddr != address(0));
+        address[] memory owners = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        owners[0] = address(0);
+        values[0] = 0;
+
+        uint256 maxMintablePerHash = 1000;
+
+        address expectedAddr = factory.predictAddress(_createSalt);
+        vm.expectEmit(true, false, false, true);
+        emit TokenCreated(
+            expectedAddr,
+            _creatorAddr,
+            _govAddr,
+            _minterAddr,
+            _name,
+            _symbol,
+            maxMintablePerHash
+        );
+
+        vm.prank(_creatorAddr);
+        address tokenAddr = factory.createToken(
+            _govAddr,
+            _minterAddr,
+            _name,
+            _symbol,
+            maxMintablePerHash,
+            owners,
+            values,
+            _createSalt
+        );
+
+        IToken token = IToken(tokenAddr);
+        assertEq(maxMintablePerHash, token.maxMintablePerHash());
+
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "MaxMintablePerHashExceeded(uint256,uint256)",
+                maxMintablePerHash + 1,
+                maxMintablePerHash
+            )
+        );
+        vm.prank(_minterAddr);
+        token.mint(_creatorAddr, maxMintablePerHash + 1);
     }
 }
 

--- a/scripts/console.ts
+++ b/scripts/console.ts
@@ -125,7 +125,7 @@ export async function createClones(
     if (withToken) {
         const tokenName: string = askFor(`token name`, EXAMPLE_TOKEN_NAME);
         const tokenSymbol: string = askFor(`token symbol`, EXAMPLE_TOKEN_SYMBOL);
-        const maxMintablePerHash: BigNumberish = askForNumber(`max mintable per hash`);
+        const maxMintablePerHash: BigNumberish = askForNumber(`max mintable per hash (0 indicates no max)`, "0");
         const buildDistribution: boolean = askYesNo(`Do you want to add an Initial Distribution?`);
 
         const owners: string[] = [];


### PR DESCRIPTION
## **Description**

Treat a zero value for `maxMintablePerHash` to be no maximum. This allows any value to be minted for a particular git hash owner.

## **Test Coverage**
```
forge test --match=testOk_createdToken
[⠊] Compiling...
[⠃] Compiling 54 files with 0.8.17
[⠒] Solc 0.8.17 finished in 63.99s
Compiler run successful

Running 2 tests for contracts/test/TokenFactory.t.sol:WhenAfterTokenCreated
[PASS] testOk_createdTokenAboveMaxMintablePerHashFailed(address,address,address,string,string,bytes32) (runs: 256, μ: 331727, ~: 324032)
[PASS] testOk_createdTokenZeroMaxMintablePerHash(address,address,address,string,string,bytes32) (runs: 256, μ: 401013, ~: 399376)
Test result: ok. 2 passed; 0 failed; finished in 32.02ms
````