### PR TITLE
read expected .env variables for Github workflows to run

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -8,10 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         env:
             MNEMONIC: ${{secrets.MNEMONIC}}
-            COINMARKETCAP_API_KEY: ${{secrets.COINMARKETCAP_API_KEY}}
             INFURA_API_KEY: ${{secrets.INFURA_API_KEY}}
-            ETHERSCAN_API_KEY: ${{secrets.ETHERSCAN_API_KEY}}
-            ALCHEMY_API_KEY: ${{secrets.ALCHEMY_API_KEY}}
         steps:
             - name: Check out the repo
               uses: actions/checkout@v3

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -63,11 +63,6 @@ if (!INFURA_API_KEY) {
     throw new Error(`Please set your INFURA_API_KEY in a .env file`);
 }
 
-const CMC_API_KEY: string | undefined = process.env.COINMARKETCAP_API_KEY;
-if (!CMC_API_KEY) {
-    throw new Error(`Please set your COINMARKETCAP_API_KEY in a .env file`);
-}
-
 function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
     let jsonRpcUrl: string;
     switch (chain) {
@@ -161,8 +156,8 @@ const config: HardhatUserConfig = {
     },
     gasReporter: {
         currency: `USD`,
-        enabled: process.env.REPORT_GAS ? true : false,
-        coinmarketcap: CMC_API_KEY,
+        enabled: REPORT_GAS,
+        coinmarketcap: process.env.CMC_API_KEY,
         excludeContracts: [`./contracts/test`],
         src: `./contracts`,
     },


### PR DESCRIPTION
# Description

Fix the failing Github CI for the integration test by reading in the Github secrets `MNEMONIC` and `INFURA_API_KEY`.

Making `CMC_API_KEY` optional since gas reporting isn't needed always.

## **Test Coverage**

https://github.com/git-consensus/contracts/actions/runs/3106295282