### PR TITLE
Obtain token factory contract from the token factory address

### DIFF
--- a/contracts/interfaces/ITokenFactory.sol
+++ b/contracts/interfaces/ITokenFactory.sol
@@ -56,5 +56,5 @@ interface ITokenFactory is ITokenFactoryEvents {
     /// @notice Predicts the address of an `IToken` deployed using CREATE2 + salt value.
     /// @param salt The salt value used by CREATE2.
     /// @return instanceAddr The address of the newly created token clone.
-    function predictAddress(bytes32 salt) external returns (address instanceAddr);
+    function predictAddress(bytes32 salt) external view returns (address instanceAddr);
 }

--- a/scripts/console.ts
+++ b/scripts/console.ts
@@ -125,7 +125,7 @@ export async function createClones(
         defaultGovernorFactoryAddr,
     );
 
-    const tokenFactory = await ethers.getContractAt(DevContracts.TOKEN_FACTORY, governorFactoryAddr);
+    const tokenFactory = await ethers.getContractAt(DevContracts.TOKEN_FACTORY, tokenFactoryAddr);
     const governorFactory = await ethers.getContractAt(DevContracts.GOVERNOR_FACTORY, governorFactoryAddr);
 
     const tokenSalt: string = saltToHex(askFor(`token salt`));
@@ -159,7 +159,6 @@ export async function createClones(
             printDistribution(owners, values);
         }
 
-        // TODO: getting incorrect values this (only the final one is correct), and they should match
         console.log(`Your predicted Token address ${etherscanAddress(network.name, tokenAddr)}\n`);
 
         console.log(`Creating token...`);
@@ -214,7 +213,6 @@ export async function createClones(
             EXAMPLE_VOTING_QUORUM_PERCENT.toString(),
         );
 
-        // TODO: getting incorrect values this (only the final one is correct), and they should match
         console.log(
             `Your predicted Governor address ${etherscanAddress(network.name, governorAddr)}`,
         );


### PR DESCRIPTION
# Description
* Obtain the `tokenFactory` contract from the `tokenFactoryAddr`, so that the predicted token address matches up with the actual deployed token address

# Example
```bash
yarn deploy --network ropsten
yarn run v1.22.19
$ npx hardhat run scripts/console.ts --network ropsten
Your available BIP-44 derivation path (m/44'/60'/0'/0) account signers to use:
1 0x55D935Ab6fE0F9a7fD2C7AB7635e164d3eD1AD24
2 0xf304255aF88d457Ba221525F3C36188016AFE08E
3 0x39E5949217828f309bc60733c9EDbF2f1F522449
4 0xc66EF5281FF553f04a64BC4700146606DB921062
5 0x6E503a5c6C41b5A68cD3Bfff98d8B04bc45CAf93
6 0xCfab128f9C4035Fa2C5990c5868f5Bc18C0309C6
7 0x1d2D5E546382aD2e7Ecf72b429d1805BD2E68F53
8 0xf586C373AA4Fe63Bc32E0BadaC5419e7b32E187C
9 0x6b14198370C4a042d8fE1429A1007C03D6A78b26
10 0x4b2814DF3E88722A0C3BcFE4Ff6616fa7Db46D46
11 0xf914179797f0165DAC9C5f624E99d0dA0A28281B
12 0x503E5165cc0d01299F0fbdE23186D4E274dF5082
13 0x615b5088D5081f86Dd80602BD220Efd18D1fdc94
14 0xbE2eaD88EC0982bd920127eBCAEb664600C6b4CD
15 0x890E51A77F6BF476F0C531D90613CE654f47502B
16 0xc2f37A6609EA6A5778001996c643F98B5C29Aa97
17 0x3bfadB57C29297d009d0e22B4c938d907BfeB1D4
18 0xC1609680E818B43d835382aa54FDC213b0f4D5A2
19 0xe55b123Ab9CBA5D3B129788627E162fe875D98FF
20 0x37c74CdA0e94C32Ef83Efdf3B6226CA3c7535e23
Please enter the signer you wish to use (1-20):
1

[1] USER - onboard a project to GitConsensus (create a Token & Governor)
[2] DEV - deploy GitConsensus, TokenFactory, or GovernorFactory
[0] CANCEL

Please enter your intended usage [1, 2, 0]: 1

[1] Token & Governor
[2] Token
[3] Governor

Enter the contract to deploy [1, 2, 3]: 1

To create your new Token & Governor, you will be asked to enter the address of the already deployed GitConsensus and Factory contracts that you want to use on ropsten. These will be defaulted from the list of the official deployed contracts on ropsten which can be found in the git-consensus/contracts/deployments.json. Developers may also wish to deploy their own versions of these contracts, in which case you want to enter the address of those instead.

Please enter the address of the GitConsensus contract (default: 0xE559bc7d69c751718C57f8181BebD0E65ed60A3f):

Please enter the address of the TokenFactory contract (default: 0xf825fCCf5D9cC7F27C6e0908Caf468402F5aF7D5):

Please enter the address of the GovernorFactory contract (default: 0x95146F88A3129263C6dd3E73e439af19DE5C184B):

Please enter token salt:
56464545
Please enter governor salt:
5645121
Please enter token name (default: ExampleToken):
asdfasd
Please enter token symbol (default: EXT):
asdfasd
Please enter max mintable per hash (0 indicates no max) (default: 0):
556
Do you want to add an Initial Distribution? [y/n]: n
Your predicted Token address https://ropsten.etherscan.io/address/0xa3E00BA53C216Cf31f257440F8Dd3936e9f2bB2d

Creating token...
Your Token has been deployed with address 0xa3E00BA53C216Cf31f257440F8Dd3936e9f2bB2d
Always include this address in your Git annotated tag message for it to be valid in Git Consensus addRelease()
Update deployments.json with new Token address 0xa3E00BA53C216Cf31f257440F8Dd3936e9f2bB2d? [y/n]: y
Please enter governor name (default: ExampleGovernor):
sdfsdf
Please enter voting delay (default: 1):
sdf
This is not a valid number
Please enter voting delay (default: 1):

Please enter voting period (default: 100800):

Please enter proposal threshold (default: 0):

Please enter quorum numerator (default: 5):

Your predicted Governor address https://ropsten.etherscan.io/address/0xa8A78c12E65ec54e388c702889e196863435e31B
Creating governor...
Your Governor has been deployed with address 0xa8A78c12E65ec54e388c702889e196863435e31B
Update deployments.json with new Governor address 0xa8A78c12E65ec54e388c702889e196863435e31B? [y/n]: y

[1] USER - onboard a project to GitConsensus (create a Token & Governor)
[2] DEV - deploy GitConsensus, TokenFactory, or GovernorFactory
[0] CANCEL

Please enter your intended usage [1, 2, 0]: 0
```