### PR TITLE
update to goerli testnet (+L2), fix eslint issues, bump NPM package to v0.0.8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,11 @@ module.exports = {
         "node/no-unpublished-import": `off`,
         "@typescript-eslint/restrict-template-expressions": `off`,
         "@typescript-eslint/explicit-function-return-type": `error`,
+        "@typescript-eslint/no-unsafe-assignment": `off`,
+        "@typescript-eslint/no-unsafe-call": `off`,
+        "@typescript-eslint/no-unsafe-member-access": `off`,
+        "@typescript-eslint/no-unsafe-argument": `off`,
+        "@typescript-eslint/no-unsafe-return": `off`,
         "@typescript-eslint/no-floating-promises": [
             `error`,
             {

--- a/deployments.json
+++ b/deployments.json
@@ -1,11 +1,11 @@
 {
     "deployments": [
         {
-            "network": "arbitrum-rinkeby",
+            "network": "arbitrum-goerli",
             "contracts": [
                 {
                     "name": "GitConsensus",
-                    "address": "0xDcd50BD640E307F79c163951E7F400EA23FA33dA"
+                    "address": "0x61A338AC596D4B70F10079EDaE846cC9723B3B15"
                 },
                 {
                     "name": "TokenFactory",
@@ -18,19 +18,19 @@
             ]
         },
         {
-            "network": "ropsten",
+            "network": "goerli",
             "contracts": [
                 {
                     "name": "GitConsensus",
-                    "address": "0xE559bc7d69c751718C57f8181BebD0E65ed60A3f"
+                    "address": "0xa203fCc21B2894Fbf76e74dbFF1a7111F6A45f46"
                 },
                 {
                     "name": "TokenFactory",
-                    "address": "0xf825fCCf5D9cC7F27C6e0908Caf468402F5aF7D5"
+                    "address": "0xA6E54184C736d019fB151ae575F07aCEDac3ACFE"
                 },
                 {
                     "name": "GovernorFactory",
-                    "address": "0x95146F88A3129263C6dd3E73e439af19DE5C184B"
+                    "address": "0xCE8267Be6E960B2abf818e7E95DAeDd4D9A22A1A"
                 }
             ]
         }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -69,13 +69,10 @@ const GAS_LIMITS = {
 
 const chainIds = {
     mainnet: 1,
-    ropsten: 3,
-    rinkeby: 4,
     goerli: 5,
     optimism: 10,
     bsc: 56,
     arbitrum: 42161,
-    "arbitrum-rinkeby": 421611,
     "arbitrum-goerli": 421613,
     avalanche: 43114,
     "polygon-mainnet": 137,
@@ -88,9 +85,6 @@ function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
     switch (chain) {
         case `arbitrum`:
             jsonRpcUrl = `https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`;
-            break;
-        case `arbitrum-rinkeby`:
-            jsonRpcUrl = `https://arb-rinkeby.g.alchemy.com/v2/${ALCHEMY_API_KEY}`;
             break;
         case `arbitrum-goerli`:
             jsonRpcUrl = `https://arb-goerli.g.alchemy.com/v2/${ALCHEMY_API_KEY}`;
@@ -173,11 +167,8 @@ const config: HardhatUserConfig = {
             gas: GAS_LIMITS.hardhat.toNumber(), // https://github.com/nomiclabs/hardhat/issues/660#issuecomment-715897156
         },
         mainnet: getChainConfig(`mainnet`),
-        ropsten: getChainConfig(`ropsten`),
-        rinkeby: getChainConfig(`rinkeby`),
         goerli: getChainConfig(`goerli`),
         arbitrum: getChainConfig("arbitrum"),
-        "arbitrum-rinkeby": getChainConfig("arbitrum-rinkeby"),
         "arbitrum-goerli": getChainConfig("arbitrum-goerli"),
         avalanche: getChainConfig(`avalanche`),
         bsc: getChainConfig(`bsc`),
@@ -195,11 +186,8 @@ const config: HardhatUserConfig = {
     etherscan: {
         apiKey: {
             mainnet: process.env.ETHERSCAN_API_KEY || ``,
-            ropsten: process.env.ETHERSCAN_API_KEY || ``,
-            rinkeby: process.env.ETHERSCAN_API_KEY || ``,
             goerli: process.env.ETHERSCAN_API_KEY || ``,
-            arbitrumOne: process.env.ARBISCAN_API_KEY || ``,
-            "arbitrum-rinkeby": process.env.ARBISCAN_API_KEY || ``,
+            arbitrum: process.env.ARBISCAN_API_KEY || ``,
             "arbitrum-goerli": process.env.ARBISCAN_API_KEY || ``,
             avalanche: process.env.SNOWTRACE_API_KEY || ``,
             optimism: process.env.OPTIMISM_API_KEY || ``,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@git-consensus/contracts",
-    "version": "0.0.6",
+    "version": "0.0.8",
     "description": "Official Git Consensus contracts, written in Solidity.",
     "type": "commonjs",
     "main": "build/scripts/index.js",

--- a/scripts/console.ts
+++ b/scripts/console.ts
@@ -34,8 +34,9 @@ import {
 } from "./deploy";
 import { saltToHex } from "./utils";
 import { GovernorFactory, TokenFactory } from "../types";
+import { GovernorImpl, TokenImpl } from "../types/contracts/clones";
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, node/no-unpublished-require
+// eslint-disable-next-line @typescript-eslint/no-var-requires, node/no-unpublished-require
 let deployments: Deployments = require(`../deployments.json`);
 
 // --- Provides a CLI to deploy the possible contracts ---
@@ -125,16 +126,16 @@ export async function createClones(
         ?.contracts.find(
             (c: { name: string }) => c.name == DevActionContract.TOKEN_FACTORY,
         )?.address;
-    const tokenFactoryAddr = askForAddress(
+    const tokenFactoryAddr: string = askForAddress(
         `of the ${DevActionContract.TOKEN_FACTORY} contract`,
         defaultTokenFactoryAddr,
     );
-    const defaultGovernorFactoryAddr = deployments.deployments
+    const defaultGovernorFactoryAddr: string | undefined = deployments.deployments
         .find((d: { network: string }) => d.network === network.name)
         ?.contracts.find(
             (c: { name: string }) => c.name == DevActionContract.GOVERNOR_FACTORY,
         )?.address;
-    const governorFactoryAddr = askForAddress(
+    const governorFactoryAddr: string = askForAddress(
         `of the ${DevActionContract.GOVERNOR_FACTORY} contract`,
         defaultGovernorFactoryAddr,
     );
@@ -188,7 +189,7 @@ export async function createClones(
 
         console.log(`Creating token...`);
 
-        const token = await createTokenClone(
+        const token: TokenImpl = await createTokenClone(
             tokenFactoryAddr,
             gitConsensusAddr,
             governorAddr,
@@ -248,7 +249,7 @@ export async function createClones(
         );
 
         console.log(`Creating governor...`);
-        const governor = await createGovernorClone(
+        const governor: GovernorImpl = await createGovernorClone(
             governorFactoryAddr,
             tokenAddr,
             signer,

--- a/scripts/const.ts
+++ b/scripts/const.ts
@@ -10,7 +10,7 @@ export const ZERO_HASH = `0x0000000000000000000000000000000000000000000000000000
 // --- Token Clone params --
 
 export const EXAMPLE_TOKEN_NAME: string = `ExampleToken`;
-export const EXAMPLE_TOKEN_SYMBOL: string= `EXT`;
+export const EXAMPLE_TOKEN_SYMBOL: string = `EXT`;
 
 // --- Governor Clone params --
 export const EXAMPLE_GOVERNOR_NAME: string = `ExampleGovernor`;

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -145,7 +145,6 @@ export async function createTokenClone(
         );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const tokenAddr: string = parseEvent(txReceipt, tokenFactory.interface)[0].args.instanceAddr;
     if (VERBOSE) console.log(`TokenClone address: ${tokenAddr}`);
     hre.tracer.nameTags[tokenAddr] = `TokenClone`;
@@ -202,7 +201,6 @@ export async function createGovernorClone(
         );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const governorAddr: string = parseEvent(txReceipt, governorFactory.interface)[0].args
         .instanceAddr;
     if (VERBOSE) console.log(`GovernorClone address: ${governorAddr}`);

--- a/scripts/testdata/example.ts
+++ b/scripts/testdata/example.ts
@@ -197,7 +197,6 @@ export async function commitExamplesWithAddr(
     localPath: string = TESTDATA_LOCAL_PATH,
 ): Promise<TestCommit[]> {
     let repo: Repository;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     if (!(await fs.pathExists(localPath))) {
         return Promise.reject(`Test data not found at ${localPath}`);
     } else {
@@ -286,7 +285,6 @@ export async function tagExamplesWithAddr(
     localPath: string = TESTDATA_LOCAL_PATH,
 ): Promise<TestTag[]> {
     let repo: Repository;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     if (!(await fs.pathExists(localPath))) {
         return Promise.reject(`Test data not found at ${localPath}`);
     } else {

--- a/scripts/testdata/git.ts
+++ b/scripts/testdata/git.ts
@@ -28,7 +28,6 @@ export async function cloneRepo(
     branchName?: string,
 ): Promise<Repository> {
     // local dir needs to be empty
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     fs.emptyDirSync(localPath);
 
     if (branchName === undefined) branchName = `master`;
@@ -140,7 +139,6 @@ export async function injectTagAddress(
     tagInterval: number = 3,
 ): Promise<Oid[]> {
     // clean up old tags if any exist
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     fs.emptyDirSync(`${repo.path()}/refs/tags/`);
 
     const commits = await getCommits(repo);


### PR DESCRIPTION
## **Description**

Removes `rinkeby` and `ropsten` testnets since they have been deprecated on October 5th.  Update deployments with `goerli` testnets, which have the newest contract ABI.

Fix eslint issues and turn several of the `unsafe` parameters off to allow for more lax TypeScript usage.

Update NPM package as master includes newest GitConsensus ABI methods, notably `hashAddr()` and `hashExists()`, needed to frontend calls.

## **Test Coverage**

- [X] My code follows the [Style Guide](../CONTRIBUTING.md#style-guide).
- [ ] My code requires a [Documentation Update](../CONTRIBUTING.md#generate-contract-api-docs).

<!--
If this PR fixes any existing issue, make it clear by commenting: "fixes #<number of issue>"/.
If this PR introduces new functionality which requires a documentation update, ensure you run `yarn doc` and/or make the appropriate changes in git-consensus/docs (after this change merges).
-->