### PR TITLE
fix ITokenFactory maxMintablePerHash doc comments

### DIFF
--- a/contracts/interfaces/ITokenFactory.sol
+++ b/contracts/interfaces/ITokenFactory.sol
@@ -36,6 +36,9 @@ interface ITokenFactory is ITokenFactoryEvents {
     ///     always be set to the Git Consensus contract's address.
     /// @param name Name of the token (e.g. "MyToken").
     /// @param symbol Symbol of the token (e.g. "MTK").
+    /// @param maxMintablePerHash The maximum value that can be minted for a single hash in
+    ///     the hashes array during `GitConsensus.addRelease(tagData, hashes, values)`. If no
+    ///     maximum is desired, set to 0.
     /// @param owners Array of addresses to receive an initial distribution of tokens. MUST
     ///     equal length of `values`.
     /// @param values Array of amounts of tokens to be given to each owner (in wei). The initial
@@ -47,7 +50,7 @@ interface ITokenFactory is ITokenFactoryEvents {
         address minterAddr,
         string calldata name,
         string calldata symbol,
-        uint256 _maxMintablePerHash,
+        uint256 maxMintablePerHash,
         address[] calldata owners,
         uint256[] calldata values,
         bytes32 salt


### PR DESCRIPTION
## **Description**

Was reading https://git-consensus.github.io/docs/api/itokenfactory/ and saw this not following the same format and have no comment. 

Copy pasted comment from IToken.

## **Test Coverage**

`forge test`: Test result: ok. 20 passed; 0 failed; finished in 12.73s
`npm run test`: 11 passing (19s)

<!--
What tests cover this change? How have you ensured that it has not broken existing functionality?
Run `forge test` to run the contract unit tests, and `npm run test` to run the integration tests.
It is recommended that you paste the relevant output of the test down below.
-->

- [X] My code follows the [Style Guide](../CONTRIBUTING.md#style-guide).
- [X] My code requires a [Documentation Update](../CONTRIBUTING.md#generate-contract-api-docs).

<!--
If this PR fixes any existing issue, make it clear by commenting: "fixes #<number of issue>"/.
If this PR introduces new functionality which requires a documentation update, ensure you run `npm run doc` and/or make the appropriate changes in git-consensus/docs (after this change merges).
-->