### PR TITLE
update nodegit usage in integration test to only clone test repo once

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,7 +4,7 @@
     "rules": {
         "singleQuote": ["error", false],
         "code-complexity": ["error", 18],
-        "compiler-version": ["error", ">=0.8.9"],
+        "compiler-version": ["error", ">=0.8.17"],
         "constructor-syntax": "error",
         "func-visibility": [
             "error",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "solidity.compileUsingRemoteVersion": "latest",
     "solidity.packageDefaultDependenciesContractsDirectory": "contracts",
-    "mochaExplorer.files": "integration/**/*.ts",
+    "mochaExplorer.files": "integration/**/*.test.ts",
     "mochaExplorer.require": "ts-node/register"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
     "solidity.compileUsingRemoteVersion": "latest",
-    "solidity.packageDefaultDependenciesContractsDirectory": "contracts"
+    "solidity.packageDefaultDependenciesContractsDirectory": "contracts",
+    "mochaExplorer.files": "integration/**/*.ts",
+    "mochaExplorer.require": "ts-node/register"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,12 +199,13 @@ On [Hardhat's website](https://hardhat.org) you will find:
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=SimonSiefke.prettier-vscode)
 - [Template String Converter](https://marketplace.visualstudio.com/items?itemName=meganrogge.template-string-converter)
 - [TypeScript Import Sorter](https://marketplace.visualstudio.com/items?itemName=mike-co.import-sorter)
+- [Mocha Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-mocha-test-adapter)
 
 &nbsp;
 
 ## [Style Guide](#style-guide)
 
-- Add Solidity comments in the [natspec](https://docs.soliditylang.org/en/v0.8.15/natspec-format.html) format.
+- Add Solidity comments in the [natspec](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html) format.
 - Always `npm run pretty` your before committing.
 - Lowercase commit message (for consistency).
 - Embed your Ethereum address in your commit message on this repository.


### PR DESCRIPTION
## **Description**

There is no need to re-clone the test repository for every integration test run. It is more efficient to do it just once when test starts and re-use.

This makes running integration tests considerable faster, makes these test compatible with parallel mode: `npx hardhat test --parallel`, and may solve some issues people were having with concurrent file writes.

Some other small misc improvements like compatibility with [Mocha Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-mocha-test-adapter) and typo fixes.

## **Test Coverage**

Before:
```txt
  Git Consensus integration tests
    commits
      ✔ should succeed single commit that have address (680ms)
      ✔ should succeed single commit that have address no space (286ms)
      - should fail all commit that have partial address
      ✔ [loop] should succeed all example commit that have address (4147ms)
      ✔ [loop] should fail all example commit that have no address (1993ms)
    releases
      ✔ should fail release with different size hash and value arrays
      ✔ [loop] should fail all example tag that have no address (1197ms)
      ✔ should fail invalid release from non-governor (261ms)
      ✔ should succeed valid release, commits from last tag to current (856ms)
      ✔ should succeed valid release, commits from any (5730ms)
      ✔ should fail to mint tokens above maxMintablePerHash (824ms)
    clones
      ✔ should create clones using arguments (55ms)


  11 passing (24s)
  1 pending
```

After:
```txt
  Git Consensus integration tests
    commits
      ✔ should succeed single commit that have address (311ms)
      ✔ should succeed single commit that have address no space (224ms)
      - should fail all commit that have partial address
      ✔ [loop] should succeed all example commit that have address (3540ms)
      ✔ [loop] should fail all example commit that have no address (1833ms)
    releases
      ✔ should fail release with different size hash and value arrays
      ✔ [loop] should fail all example tag that have no address (1066ms)
      ✔ should fail invalid release from non-governor (193ms)
      ✔ should succeed valid release, commits from last tag to current (727ms)
      ✔ should succeed valid release, commits from any (4916ms)
      ✔ should fail to mint tokens above maxMintablePerHash (689ms)
    clones
      ✔ should create clones using arguments (56ms)


  11 passing (17s)
  1 pending
```

So some performance improvement there.

- [X] My commit message [contains my Ethereum address](https://git-consensus.github.io/docs/usage/start/).
- [X] My code follows the [Style Guide](../CONTRIBUTING.md#style-guide).
- [ ] My code requires a [Documentation Update](../CONTRIBUTING.md#generate-contract-api-docs).

<!--
If this PR fixes any existing issue, make it clear by commenting: "fixes #<number of issue>"/.
If this PR introduces new functionality which requires a documentation update, ensure you run `npm run doc` and/or make the appropriate changes in git-consensus/docs (after this change merges).
-->