### PR TITLE
parameterize block explorer URLs and move to hardhat config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -55,24 +55,27 @@ const GAS_LIMITS = {
 };
 
 const chainIds = {
-    mainnet: 1,
-    goerli: 5,
-    optimism: 10,
-    bsc: 56,
     arbitrum: 42161,
     "arbitrum-goerli": 421613,
     avalanche: 43114,
     "avalanche-fuji": 43113,
+    bsc: 56,
+    goerli: 5,
+    hardhat: 31337,
+    mainnet: 1,
+    optimism: 10,
     "polygon-mainnet": 137,
     "polygon-mumbai": 80001,
-    hardhat: 31337,
 };
 
 function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
     let jsonRpcUrl: string;
     switch (chain) {
-        case `optimism`:
-            jsonRpcUrl = `https://mainnet.optimism.io`;
+        case `arbitrum`:
+            jsonRpcUrl = `https://arb-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
+            break;
+        case `arbitrum-goerli`:
+            jsonRpcUrl = `https://arb-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
             break;
         case `avalanche`:
             jsonRpcUrl = `https://api.avax.network/ext/bc/C/rpc`;
@@ -83,11 +86,8 @@ function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
         case `bsc`:
             jsonRpcUrl = `https://bsc-dataseed1.binance.org`;
             break;
-        case `arbitrum`:
-            jsonRpcUrl = `https://arb-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
-            break;
-        case `arbitrum-goerli`:
-            jsonRpcUrl = `https://arb-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
+        case `optimism`:
+            jsonRpcUrl = `https://mainnet.optimism.io`;
             break;
         case `polygon-mainnet`:
             jsonRpcUrl = `https://polygon-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
@@ -116,14 +116,6 @@ export enum UrlType {
 
 export function explorerUrl(net: string, type: UrlType, param: string): string {
     switch (net) {
-        case `mainnet`:
-            return `https://etherscan.io/${type}/${param}`;
-        case `goerli`:
-            return `https://goerli.etherscan.io/${type}/${param}`;
-        case `optimism`:
-            return `https://optimistic.etherscan.io/${type}/${param}`;
-        case `bsc`:
-            return `https://bscscan.com/${type}/${param}`;
         case `arbitrum`:
             return `https://arbiscan.io/${type}/${param}`;
         case `arbitrum-goerli`:
@@ -132,6 +124,14 @@ export function explorerUrl(net: string, type: UrlType, param: string): string {
             return `https://snowtrace.io/${type}/${param}`;
         case `avalanche-fuji`:
             return `https://testnet.snowtrace.io/${type}/${param}`;
+        case `bsc`:
+            return `https://bscscan.com/${type}/${param}`;
+        case `goerli`:
+            return `https://goerli.etherscan.io/${type}/${param}`;
+        case `mainnet`:
+            return `https://etherscan.io/${type}/${param}`;
+        case `optimism`:
+            return `https://optimistic.etherscan.io/${type}/${param}`;
         case `polygon-mainnet`:
             return `https://polygonscan.com/${type}/${param}`;
         case `polygon-mumbai`:
@@ -198,13 +198,13 @@ const config: HardhatUserConfig = {
             blockGasLimit: GAS_LIMITS.hardhat.toNumber(),
             gas: GAS_LIMITS.hardhat.toNumber(), // https://github.com/nomiclabs/hardhat/issues/660#issuecomment-715897156
         },
-        mainnet: getChainConfig(`mainnet`),
-        goerli: getChainConfig(`goerli`),
         arbitrum: getChainConfig(`arbitrum`),
         "arbitrum-goerli": getChainConfig(`arbitrum-goerli`),
         avalanche: getChainConfig(`avalanche`),
         "avalanche-fuji": getChainConfig(`avalanche-fuji`),
         bsc: getChainConfig(`bsc`),
+        goerli: getChainConfig(`goerli`),
+        mainnet: getChainConfig(`mainnet`),
         optimism: getChainConfig(`optimism`),
         "polygon-mainnet": getChainConfig(`polygon-mainnet`),
         "polygon-mumbai": getChainConfig(`polygon-mumbai`),

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -64,6 +64,7 @@ const chainIds = {
     hardhat: 31337,
     mainnet: 1,
     optimism: 10,
+    "optimism-goerli": 420,
     "polygon-mainnet": 137,
     "polygon-mumbai": 80001,
 };
@@ -88,6 +89,9 @@ function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
             break;
         case `optimism`:
             jsonRpcUrl = `https://mainnet.optimism.io`;
+            break;
+        case `optimism-goerli`:
+            jsonRpcUrl = `https://opt-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
             break;
         case `polygon-mainnet`:
             jsonRpcUrl = `https://polygon-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
@@ -132,6 +136,8 @@ export function explorerUrl(net: string, type: UrlType, param: string): string {
             return `https://etherscan.io/${type}/${param}`;
         case `optimism`:
             return `https://optimistic.etherscan.io/${type}/${param}`;
+        case `optimism-goerli`:
+            return `https://goerli-optimism.etherscan.io/${type}/${param}`;
         case `polygon-mainnet`:
             return `https://polygonscan.com/${type}/${param}`;
         case `polygon-mumbai`:
@@ -206,6 +212,7 @@ const config: HardhatUserConfig = {
         goerli: getChainConfig(`goerli`),
         mainnet: getChainConfig(`mainnet`),
         optimism: getChainConfig(`optimism`),
+        "optimism-goerli": getChainConfig(`optimism-goerli`),
         "polygon-mainnet": getChainConfig(`polygon-mainnet`),
         "polygon-mumbai": getChainConfig(`polygon-mumbai`),
     },
@@ -218,14 +225,15 @@ const config: HardhatUserConfig = {
     },
     etherscan: {
         apiKey: {
-            mainnet: process.env.ETHERSCAN_API_KEY || ``,
-            goerli: process.env.ETHERSCAN_API_KEY || ``,
             arbitrum: process.env.ARBISCAN_API_KEY || ``,
             "arbitrum-goerli": process.env.ARBISCAN_API_KEY || ``,
             avalanche: process.env.SNOWTRACE_API_KEY || ``,
             "avalanche-fuji": process.env.SNOWTRACE_API_KEY || ``,
-            optimism: process.env.OPTIMISM_API_KEY || ``,
             bsc: process.env.BSCSCAN_API_KEY || ``,
+            goerli: process.env.ETHERSCAN_API_KEY || ``,
+            mainnet: process.env.ETHERSCAN_API_KEY || ``,
+            optimism: process.env.OPTIMISM_API_KEY || ``,
+            "optimism-goerli": process.env.OPTIMISM_API_KEY || ``,
             "polygon-mainnet": process.env.POLYGONSCAN_API_KEY || ``,
             "polygon-mumbai": process.env.POLYGONSCAN_API_KEY || ``,
         },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import "@nomiclabs/hardhat-ethers";
 import "@nomiclabs/hardhat-etherscan";
 import "hardhat-gas-reporter";
@@ -63,6 +62,7 @@ const chainIds = {
     arbitrum: 42161,
     "arbitrum-goerli": 421613,
     avalanche: 43114,
+    "avalanche-fuji": 43113,
     "polygon-mainnet": 137,
     "polygon-mumbai": 80001,
     hardhat: 31337,
@@ -71,17 +71,29 @@ const chainIds = {
 function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
     let jsonRpcUrl: string;
     switch (chain) {
+        case `optimism`:
+            jsonRpcUrl = `https://mainnet.optimism.io`;
+            break;
+        case `avalanche`:
+            jsonRpcUrl = `https://api.avax.network/ext/bc/C/rpc`;
+            break;
+        case `avalanche-fuji`:
+            jsonRpcUrl = `https://api.avax-test.network/ext/bc/C/rpc`;
+            break;
+        case `bsc`:
+            jsonRpcUrl = `https://bsc-dataseed1.binance.org`;
+            break;
         case `arbitrum`:
             jsonRpcUrl = `https://arb-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
             break;
         case `arbitrum-goerli`:
             jsonRpcUrl = `https://arb-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
             break;
-        case `avalanche`:
-            jsonRpcUrl = `https://api.avax.network/ext/bc/C/rpc`;
+        case `polygon-mainnet`:
+            jsonRpcUrl = `https://polygon-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
             break;
-        case `bsc`:
-            jsonRpcUrl = `https://bsc-dataseed1.binance.org`;
+        case `polygon-mumbai`:
+            jsonRpcUrl = `https://polygon-mumbai.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
             break;
         default:
             jsonRpcUrl = `https://${chain}.infura.io/v3/${process.env.INFURA_API_KEY}`;
@@ -95,6 +107,38 @@ function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
         chainId: chainIds[chain],
         url: jsonRpcUrl,
     };
+}
+
+export enum UrlType {
+    ADDRESS = `address`,
+    TX = `tx`,
+}
+
+export function explorerUrl(net: string, type: UrlType, param: string): string {
+    switch (net) {
+        case `mainnet`:
+            return `https://etherscan.io/${type}/${param}`;
+        case `goerli`:
+            return `https://goerli.etherscan.io/${type}/${param}`;
+        case `optimism`:
+            return `https://optimistic.etherscan.io/${type}/${param}`;
+        case `bsc`:
+            return `https://bscscan.com/${type}/${param}`;
+        case `arbitrum`:
+            return `https://arbiscan.io/${type}/${param}`;
+        case `arbitrum-goerli`:
+            return `https://goerli.arbiscan.io/${type}/${param}`;
+        case `avalanche`:
+            return `https://snowtrace.io/${type}/${param}`;
+        case `avalanche-fuji`:
+            return `https://testnet.snowtrace.io/${type}/${param}`;
+        case `polygon-mainnet`:
+            return `https://polygonscan.com/${type}/${param}`;
+        case `polygon-mumbai`:
+            return `https://mumbai.polygonscan.com/${type}/${param}`;
+        default:
+            return `https://${net}.etherscan.io/${type}/${param}`;
+    }
 }
 
 // try use forge config
@@ -156,9 +200,10 @@ const config: HardhatUserConfig = {
         },
         mainnet: getChainConfig(`mainnet`),
         goerli: getChainConfig(`goerli`),
-        arbitrum: getChainConfig("arbitrum"),
-        "arbitrum-goerli": getChainConfig("arbitrum-goerli"),
+        arbitrum: getChainConfig(`arbitrum`),
+        "arbitrum-goerli": getChainConfig(`arbitrum-goerli`),
         avalanche: getChainConfig(`avalanche`),
+        "avalanche-fuji": getChainConfig(`avalanche-fuji`),
         bsc: getChainConfig(`bsc`),
         optimism: getChainConfig(`optimism`),
         "polygon-mainnet": getChainConfig(`polygon-mainnet`),
@@ -178,6 +223,7 @@ const config: HardhatUserConfig = {
             arbitrum: process.env.ARBISCAN_API_KEY || ``,
             "arbitrum-goerli": process.env.ARBISCAN_API_KEY || ``,
             avalanche: process.env.SNOWTRACE_API_KEY || ``,
+            "avalanche-fuji": process.env.SNOWTRACE_API_KEY || ``,
             optimism: process.env.OPTIMISM_API_KEY || ``,
             bsc: process.env.BSCSCAN_API_KEY || ``,
             "polygon-mainnet": process.env.POLYGONSCAN_API_KEY || ``,

--- a/scripts/console.ts
+++ b/scripts/console.ts
@@ -36,7 +36,7 @@ import {
     deployTokenFactory,
 } from "./deploy";
 import { saltToHex } from "./utils";
-import { GAS_MODE } from "../hardhat.config";
+import { explorerUrl, UrlType, GAS_MODE } from "../hardhat.config";
 
 // --- Provides a CLI to deploy the possible contracts ---
 
@@ -201,7 +201,13 @@ export async function createClones(
             printDistribution(owners, values);
         }
 
-        console.log(`Your predicted Token address ${etherscanAddress(network.name, tokenAddr)}\n`);
+        console.log(
+            `Your predicted Token address ${explorerUrl(
+                network.name,
+                UrlType.ADDRESS,
+                tokenAddr,
+            )}\n`,
+        );
 
         console.log(`Creating token...`);
 
@@ -263,7 +269,11 @@ export async function createClones(
         );
 
         console.log(
-            `Your predicted Governor address ${etherscanAddress(network.name, governorAddr)}`,
+            `Your predicted Governor address ${explorerUrl(
+                network.name,
+                UrlType.ADDRESS,
+                governorAddr,
+            )}`,
         );
 
         console.log(`Creating governor...`);
@@ -322,9 +332,15 @@ async function trackDeployment<T extends Contract>(
             const net = await contract.provider.getNetwork();
 
             console.log(`Deployer address: ${contract.deployTransaction.from}`);
-            console.log(`${name} address: ${etherscanAddress(net.name, contract.address)}`);
             console.log(
-                `${name} transaction: ${etherscanTx(net.name, contract.deployTransaction.hash)}`,
+                `${name} address: ${explorerUrl(net.name, UrlType.ADDRESS, contract.address)}`,
+            );
+            console.log(
+                `${name} transaction: ${explorerUrl(
+                    net.name,
+                    UrlType.TX,
+                    contract.deployTransaction.hash,
+                )}`,
             );
 
             if (
@@ -587,36 +603,6 @@ function printDistribution(owners: string[], values: BigNumberish[]): void {
         console.log(`${owners[i]}   | ${values[i].toString()}`);
     }
     console.log(`\n`);
-}
-
-// --- External link helpers ---
-
-// TODO: parameterize the path that follows *.io/, add rest of L2s, move function to hardhat config
-
-function etherscanAddress(net: string, addr: string): string {
-    if (net == `mainnet`) {
-        return `https://etherscan.io/address/${addr}`;
-    }
-    if (net == `arbitrum`) {
-        return `https://arbiscan.io/address/${addr}`;
-    }
-    if (net == `arbitrum-goerli`) {
-        return `https://goerli.arbiscan.io/address/${addr}`;
-    }
-    return `https://${net}.etherscan.io/address/${addr}`;
-}
-
-function etherscanTx(net: string, txHash: string): string {
-    if (net == `mainnet`) {
-        return `https://etherscan.io/tx/${txHash}`;
-    }
-    if (net == `arbitrum`) {
-        return `https://arbiscan.io/tx/${txHash}`;
-    }
-    if (net == `arbitrum-goerli`) {
-        return `https://goerli.arbiscan.io/tx/${txHash}`;
-    }
-    return `https://${net}.etherscan.io/tx/${txHash}`;
 }
 
 main().catch(error => {


### PR DESCRIPTION
## **Description**

Merges the two different functions we have into one, and move into hardhat config, which seems better suited for this since it:
1. is near the rest of the network configs
2. is a better place to be references globally by the project

Suggested by @DmitriyShepelev [here](https://github.com/git-consensus/contracts/pull/54#discussion_r1008931759).

## **Test Coverage**

N/A

- [X] My commit message [contains my Ethereum address](https://git-consensus.github.io/docs/usage/start/).
- [X] My code follows the [Style Guide](../CONTRIBUTING.md#style-guide).
- [ ] My code requires a [Documentation Update](../CONTRIBUTING.md#generate-contract-api-docs).

<!--
If this PR fixes any existing issue, make it clear by commenting: "fixes #<number of issue>"/.
If this PR introduces new functionality which requires a documentation update, ensure you run `npm run doc` and/or make the appropriate changes in git-consensus/docs (after this change merges).
-->